### PR TITLE
Fixing equality test for shorthand ++ and --.

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -52,7 +52,7 @@ module.exports = (robot) ->
     name = (name.replace /(^\s*@)|([,:\s]*$)/g, "").trim().toLowerCase() if name
 
     # check whether a name was specified. use MRU if not
-    unless name?
+    unless name? && name != ''
       [name, lastReason] = scoreKeeper.last(room)
       reason = lastReason if !reason? && lastReason?
 


### PR DESCRIPTION
Hi!

I noticed when someone writes `dan++` and then someone after that just writes `++`, nothing happens. I checked this out and ran it locally, and it looks like when someone writes `++` we get `name` equal to an empty string (`''`). Looking at the code, this happens because  `unless name?` doesn't catch empty strings (`?` only check for definedness, not emptiness).

This PR updates the check to also check if the string is empty.