### PR TITLE
only match exactly "++" and "--"

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -37,7 +37,7 @@ module.exports = (robot) ->
     # allow for spaces after the thing being upvoted (@user ++)
     \s*
     # the increment/decrement operator ++ or --
-    ([-+]{2}|—)
+    (\+\+|--|—)
     # optional reason for the plusplus
     (?:\s+(?:for|because|cause|cuz)\s+(.+))?
     $ # end of line


### PR DESCRIPTION
Current regex matches `++`, `--`, `+-`, and `-+`. After, because of the if/else from L60-63, `+-` and `-+` will subtract from the user. This regex will match specifically `++` and `--`.

<img width="266" alt="screen shot 2015-09-07 at 6 44 23 pm" src="https://cloud.githubusercontent.com/assets/2453653/9723499/7d706abc-5590-11e5-8df7-985ca7903e21.png">
