### PR TITLE
Fixes the regex to allow for dashes in usernames.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-plusplus",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A hubot script for adding or removing points",
   "main": "index.coffee",
   "scripts": {

--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -35,7 +35,7 @@ module.exports = (robot) ->
     # from beginning of line
     ^
     # the thing being upvoted, which is any number of words and spaces
-    ([\s\w'@.-:]*)
+    ([\s\w'@.\-:]*)
     # allow for spaces after the thing being upvoted (@user ++)
     \s*
     # the increment/decrement operator ++ or --


### PR DESCRIPTION
Currently the `-` in the below regex doesn't actually work. It needs to be escaped to register.

Also submitted a PR [here](https://github.com/ajacksified/hubot-plusplus/pull/52). Confused as to which one to send the PR to...