### PR TITLE
Add support for French reasons

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -41,7 +41,7 @@ module.exports = (robot) ->
     # the increment/decrement operator ++ or --
     ([-+]{2}|—)
     # optional reason for the plusplus
-    (?:\s+(?:for|because|cause|cuz)\s+(.+))?
+    (?:\s+(?:for|because|cause|cuz|pour)\s+(.+))?
     $ # end of line
   ///i, (msg) ->
     # let's get our local vars in place
@@ -98,7 +98,7 @@ module.exports = (robot) ->
     # thing to be erased
     ([\s\w'@.-:]+?)
     # optionally erase a reason from thing
-    (?:\s+(?:for|because|cause|cuz)\s+(.+))?
+    (?:\s+(?:for|because|cause|cuz|pour)\s+(.+))?
     $ # eol
   ///i, (msg) ->
     [__, name, reason] = msg.match


### PR DESCRIPTION
This adds a simple keyword "pour", which means 'for' in French, more or less.
This is sorta useful for conversations we encounter in international groups :+1: 

Example: We wanted to do a `@ my_colleague ++ "pour les _RAISONS-BLAHBLAH_" and if bot could parse "pour" keyword all would work perfect :grin: 